### PR TITLE
chore: Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "tatematsu-k"
+    labels:
+      - "dependencies"
+      - "ruby"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "tatematsu-k"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## 概要
Dependabotの設定ファイルを追加しました。

## 変更内容
- `.github/dependabot.yml` を追加
- Bundlerの依存関係を週次で監視
- GitHub Actionsの依存関係を週次で監視

## 設定内容
- **Bundler**: 週1回（月曜日9:00）にチェック、最大10件のPR
- **GitHub Actions**: 週1回（月曜日9:00）にチェック、最大5件のPR
- 自動レビュアー: `tatematsu-k`
- ラベル: `dependencies`, `ruby`, `github-actions`

これにより、依存関係の更新が定期的にチェックされ、プルリクエストが自動で作成されます。