### PR TITLE
fix: Correct paths in Generate index page step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,16 +110,17 @@ jobs:
           TEMPLATE_FILE="../email_domain_checker/docs-templates/index.html"
           SCRIPT_FILE="../email_domain_checker/.github/scripts/generate-index.sh"
           if [[ -f "$TEMPLATE_FILE" && -f "$SCRIPT_FILE" ]]; then
-            cp "$TEMPLATE_FILE" .
-            cp "$SCRIPT_FILE" .github/scripts/
-            chmod +x .github/scripts/generate-index.sh
-            .github/scripts/generate-index.sh
+            # Copy template to docs-templates directory for script
+            mkdir -p docs-templates
+            cp "$TEMPLATE_FILE" docs-templates/index.html
+            # Run script with correct paths
+            TEMPLATE_FILE="docs-templates/index.html" OUTPUT_FILE="index.html" bash "$SCRIPT_FILE"
           else
             echo "Warning: Template or script not found, creating basic index"
             cat > index.html << 'EOF'
-          <!DOCTYPE html>
-          <html><head><meta http-equiv="refresh" content="0; url=latest/"></head></html>
-          EOF
+<!DOCTYPE html>
+<html><head><meta http-equiv="refresh" content="0; url=latest/"></head></html>
+EOF
           fi
 
       - name: Upload pages artifact


### PR DESCRIPTION
## Summary

Fix the "Generate index page" step that was failing with exit code 1. The issue was related to incorrect path resolution for template files and script execution.

## Changes

- Fix template file path resolution in the Generate index page step
- Set environment variables (`TEMPLATE_FILE` and `OUTPUT_FILE`) for script execution
- Ensure script runs from the correct directory context
- Copy template to the expected location before running the script

## Problem

The previous implementation was trying to run the script without properly setting up the template file path, causing the script to fail when looking for `docs-templates/index.html`.

## Solution

1. Copy the template file to `docs-templates/index.html` in the artifact directory
2. Set environment variables when executing the script
3. Run the script with `bash` to ensure proper execution

## Testing

This fix should resolve the workflow failure. The script will now correctly:
- Find the template file
- Generate the version list
- Create the index.html file successfully