### PR TITLE
Fix documentation deployment error on tag push

### DIFF
--- a/.github/scripts/generate-index.sh
+++ b/.github/scripts/generate-index.sh
@@ -35,8 +35,18 @@ fi
 VERSION_LIST=$(generate_version_list)
 
 # Replace placeholder in template
-if ! sed "s|{{VERSION_LIST}}|$VERSION_LIST|" "$TEMPLATE_FILE" > "$OUTPUT_FILE"; then
-    echo "Error: Failed to generate index.html" >&2
+# Use a temporary file to avoid issues with special characters
+TEMP_FILE=$(mktemp)
+trap "rm -f $TEMP_FILE" EXIT
+
+if ! sed "s|{{VERSION_LIST}}|$VERSION_LIST|" "$TEMPLATE_FILE" > "$TEMP_FILE"; then
+    echo "Error: Failed to process template" >&2
+    exit 1
+fi
+
+# Move temp file to output
+if ! mv "$TEMP_FILE" "$OUTPUT_FILE"; then
+    echo "Error: Failed to write output file" >&2
     exit 1
 fi
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -112,13 +112,58 @@ jobs:
 
       - name: Generate index page
         run: |
-          cd ../pages-artifact
-          TEMPLATE_FILE="../email_domain_checker/docs-templates/index.html"
-          SCRIPT_FILE="../email_domain_checker/.github/scripts/generate-index.sh"
-          if [[ -f "$TEMPLATE_FILE" && -f "$SCRIPT_FILE" ]]; then
+          # Determine the correct path to pages-artifact
+          # It should be in the parent directory of the workspace
+          WORKSPACE_NAME="${GITHUB_WORKSPACE##*/}"
+          PAGES_ARTIFACT_DIR="../pages-artifact"
+
+          # Ensure we're in the workspace root
+          cd "$GITHUB_WORKSPACE"
+
+          # Check if pages-artifact directory exists, create if not
+          if [[ ! -d "$PAGES_ARTIFACT_DIR" ]]; then
+            echo "Warning: pages-artifact directory not found, creating it"
+            mkdir -p "$PAGES_ARTIFACT_DIR"
+          fi
+
+          cd "$PAGES_ARTIFACT_DIR"
+
+          # Try to find template and script files from multiple locations
+          TEMPLATE_FILE=""
+          SCRIPT_FILE=""
+
+          # First, try from the workspace root
+          if [[ -f "../${WORKSPACE_NAME}/docs-templates/index.html" ]]; then
+            TEMPLATE_FILE="../${WORKSPACE_NAME}/docs-templates/index.html"
+          elif [[ -f "../email_domain_checker/docs-templates/index.html" ]]; then
+            TEMPLATE_FILE="../email_domain_checker/docs-templates/index.html"
+          elif [[ -f "docs-templates/index.html" ]]; then
+            TEMPLATE_FILE="docs-templates/index.html"
+          fi
+
+          if [[ -f "../${WORKSPACE_NAME}/.github/scripts/generate-index.sh" ]]; then
+            SCRIPT_FILE="../${WORKSPACE_NAME}/.github/scripts/generate-index.sh"
+          elif [[ -f "../email_domain_checker/.github/scripts/generate-index.sh" ]]; then
+            SCRIPT_FILE="../email_domain_checker/.github/scripts/generate-index.sh"
+          elif [[ -f ".github/scripts/generate-index.sh" ]]; then
+            SCRIPT_FILE=".github/scripts/generate-index.sh"
+          fi
+
+          echo "Checking for template and script files..."
+          echo "Current directory: $(pwd)"
+          echo "Workspace: $GITHUB_WORKSPACE"
+          echo "Template file: ${TEMPLATE_FILE:-not found}"
+          echo "Script file: ${SCRIPT_FILE:-not found}"
+
+          if [[ -n "$TEMPLATE_FILE" && -n "$SCRIPT_FILE" ]]; then
             mkdir -p docs-templates
             cp "$TEMPLATE_FILE" docs-templates/index.html
-            TEMPLATE_FILE="docs-templates/index.html" OUTPUT_FILE="index.html" bash "$SCRIPT_FILE"
+            echo "Running index generation script..."
+            TEMPLATE_FILE="docs-templates/index.html" OUTPUT_FILE="index.html" bash "$SCRIPT_FILE" || {
+              echo "Error: Script execution failed, creating basic index"
+              echo '<!DOCTYPE html>' > index.html
+              echo '<html><head><meta http-equiv="refresh" content="0; url=latest/"></head></html>' >> index.html
+            }
           else
             echo "Warning: Template or script not found, creating basic index"
             echo '<!DOCTYPE html>' > index.html


### PR DESCRIPTION
## Problem

The documentation deployment was failing when tags were pushed. The `Generate index page` step was failing because `cd ../pages-artifact` couldn't find the directory.

## Changes

1. **Fixed directory path resolution**
   - Explicitly navigate to workspace root using `$GITHUB_WORKSPACE`
   - Added existence check and auto-creation for `pages-artifact` directory

2. **Improved template and script file discovery**
   - Added fallback logic to search for files from multiple paths
   - Dynamically get workspace name to construct paths

3. **Enhanced error handling**
   - Changed `generate-index.sh` to use temporary files
   - Added fallback handling when script execution fails

4. **Added debug information**
   - Output current directory and workspace path for troubleshooting

## Testing

- [ ] Verify deployment works correctly when tags are pushed
- [ ] Verify deployment works correctly when pushing to main branch

## Related Issue

https://github.com/tatematsu-k/email_domain_checker/actions/runs/19136199058/job/54688795378